### PR TITLE
Use XSeries 8.5.0.1 to fix 1.17.1 issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     implementation 'de.themoep:inventorygui:1.5-SNAPSHOT'
 
-    implementation 'com.github.cryptomorin:XSeries:8.5.0'
+    implementation 'com.github.cryptomorin:XSeries:8.5.0.1'
 
     implementation 'net.wesjd:anvilgui:1.5.3-SNAPSHOT'
 


### PR DESCRIPTION
8.5.0.1 change: https://github.com/CryptoMorin/XSeries/commit/7477ef5c434c40c89b9a6f4e180f4d5d69672e2f

Startup log of the issue:

```
[19:18:26 INFO]: [HPWP] Enabling HPWP v1.5.1
>.... [19:18:27 WARN]: java.lang.NoSuchFieldException: no such field:
>net.minecraft.server.level.EntityPlayer.playerConnection/net.minecraft.server.network.PlayerConnection/getField
>.... [19:18:27 WARN]: at
>java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:978)#
>Please enter the commit message for your changes. Lines starting ....
>[19:18:27 WARN]: at
>java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1117)#
>with '#' will be ignored, and an empty message aborts the commit. ....
>[19:18:27 WARN]: at
>java.base/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3641)#
>.... [19:18:27 WARN]: at
>java.base/java.lang.invoke.MethodHandles$Lookup.findGetter(MethodHandles.java:3019)#
>Date: Sun Dec 12 19:27:50 2021 -0600 .... [19:18:27 WARN]: at
>HPWP.jar//com.heretere.hpwp.libs.xseries.ReflectionUtils.<clinit>(ReflectionUtils.java:107)#
>.... [19:18:27 WARN]: at
>HPWP.jar//com.heretere.hpwp.libs.xseries.SkullUtils.<clinit>(SkullUtils.java:71)#
>On branch master .... [19:18:27 WARN]: at
>HPWP.jar//com.heretere.hpwp.gui.util.items.ItemFactory.create(ItemFactory.java:59)#
>Your branch and 'origin/master' have diverged, .... [19:18:27 WARN]: at
>HPWP.jar//com.heretere.hpwp.gui.main.tunnels.ChatTunnelsConfigGui.<init>(ChatTunnelsConfigGui.java:98)#
>and have 2 and 3 different commits each, respectively. .... [19:18:27 WARN]:
>at HPWP.jar//com.heretere.hpwp.gui.main.MainMenu.<init>(MainMenu.java:71)#
>(use "git pull" to merge the remote branch into yours) .... [19:18:27 WARN]:
>at
>HPWP.jar//com.heretere.hpwp.PerWorldPlugins.onEnable(PerWorldPlugins.java:106)#
>.... [19:18:27 WARN]: at
>org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264)# Changes to
>be committed: .... [19:18:27 WARN]: at
>org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370)#
>modified: build.gradle .... [19:18:27 WARN]: at
>org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:500)#
>.... [19:18:27 WARN]: at
>org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugin(CraftServer.java:561)
>.... [19:18:27 WARN]: at
>org.bukkit.craftbukkit.v1_17_R1.CraftServer.enablePlugins(CraftServer.java:475)
>.... [19:18:27 WARN]: at
>net.minecraft.server.dedicated.DedicatedServer.init(DedicatedServer.java:288)
>.... [19:18:27 WARN]: at
>net.minecraft.server.MinecraftServer.x(MinecraftServer.java:1220) ....
>[19:18:27 WARN]: at
>net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319)
>.... [19:18:27 WARN]: at java.base/java.lang.Thread.run(Thread.java:833) ....
>[19:18:27 WARN]: Caused by: java.lang.NoSuchFieldError: playerConnection ....
>[19:18:27 WARN]: at
>java.base/java.lang.invoke.MethodHandleNatives.resolve(Native Method) ....
>[19:18:27 WARN]: at
>java.base/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:1085)
>.... [19:18:27 WARN]: at
>java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1114)
>.... [19:18:27 WARN]: ... 17 more
```